### PR TITLE
Future dates only

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -161,7 +161,7 @@ function App() {
   const endDate = startEnd.start ? 
     <div className="pair">
       <label htmlFor="end">Vacation End</label>
-      <input type="date" min={new Date(startEnd.start).toISOString().split('T')[0]} name="end" id="end" defaultValue={`${startEnd.start.toISOString().slice(0,10)}`} onChange={handleStartEndChange}/>
+      <input autoFocus type="date" min={new Date(startEnd.start).toISOString().split('T')[0]} name="end" id="end" defaultValue={`${startEnd.start.toISOString().slice(0,10)}`} onChange={handleStartEndChange}/>
     </div> : ''
 
   return (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -161,7 +161,7 @@ function App() {
   const endDate = startEnd.start ? 
     <div className="pair">
       <label htmlFor="end">Vacation End</label>
-      <input type="date" name="end" id="end" defaultValue={`${startEnd.start.toISOString().slice(0,10)}`} onChange={handleStartEndChange}/>
+      <input type="date" min={new Date(startEnd.start).toISOString().split('T')[0]} name="end" id="end" defaultValue={`${startEnd.start.toISOString().slice(0,10)}`} onChange={handleStartEndChange}/>
     </div> : ''
 
   return (
@@ -192,7 +192,7 @@ function App() {
               <h2>Add Vacation!</h2>
               <div className="pair">
                 <label htmlFor="start">Vacation Start</label>
-                <input type="date" name="start" id="start" onChange={handleStartEndChange}/>
+                  <input type="date" min={new Date().toISOString().split('T')[0]} name="start" id="start" onChange={handleStartEndChange}/>
               </div>
               {endDate}
               {hrs()}

--- a/src/DateEntry.tsx
+++ b/src/DateEntry.tsx
@@ -29,7 +29,7 @@ export const DateEntry = ({ f, i, id, resetDates, editDates }: Props) => {
         return (
             <div className="row editHourForm">
                 <button className='delete' onClick={() =>  setEditDate(false)}>Save</button>
-                <input type="date" alt='dateField' name={`${i}-date`} defaultValue={f.date.toISOString().slice(0, 10)} onBlur={editDates}/>
+                <input type="date" min={new Date().toISOString().split('T')[0]} alt='dateField' name={`${i}-date`} defaultValue={f.date.toISOString().slice(0, 10)} onBlur={editDates}/>
                 <div className='edit-pair'>{f.hrs}</div>
                 <div className={`edit-pair ${f.overMax ? 'over' : ''}`}>{f.totalHrs}</div>
             </div>


### PR DESCRIPTION
I did a few things here:

- set the "min" date for the "vacation start date" to be the current day
- set the "min" date for the "vacation end date" to be the current "vacation start date" (you can't take a vacation backwards!)
- set the "min" date to the current day for whenever you're editing a vacation day
- autofocus the "end date" field after the "start date" is selected
